### PR TITLE
Set `err`  only if an error occurred

### DIFF
--- a/ch5/fetch/main.go
+++ b/ch5/fetch/main.go
@@ -34,7 +34,7 @@ func fetch(url string) (filename string, n int64, err error) {
 	}
 	n, err = io.Copy(f, resp.Body)
 	// Close file, but prefer error from Copy, if any.
-	if closeErr := f.Close(); err == nil {
+	if closeErr := f.Close(); closeErr != nil && err == nil {
 		err = closeErr
 	}
 	return local, n, err


### PR DESCRIPTION
The previous version works, but is confusing because it sets `err` even if no error occurred. In the event no error resulted during `io.Copy`, `err` would be set whether or not `f.Close()` returned an error. It _does_ work, because it could just be setting `err` to `nil`, but it's confusing to read. The suggested update removes the cause for my confusion and only sets `err` with the error from `f.Close()` in the event that an error actually occurred from that statement, and leaves in place the consideration that no error had occurred from `io.Copy` as well.